### PR TITLE
to JuliaFolds2 and minimal interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ChunkSplitters"
 uuid = "ae650224-84b6-46f8-82ea-d812ca08434e"
 authors = ["Leandro Martinez <lmartine@unicamp.br> and contributors"]
-version = "2.1.1-DEV"
+version = "2.2.0"
 
 [deps]
 TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://m3g.github.io/ChunkSplitters.jl/stable)
-[![Stable](https://img.shields.io/badge/docs-dev-blue.svg)](https://m3g.github.io/ChunkSplitters.jl/dev)
-[![Tests](https://img.shields.io/badge/build-passing-green)](https://github.com/m3g/ChunkSplitters.jl/actions)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaFolds2.github.io/ChunkSplitters.jl/stable)
+[![Stable](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaFolds2.github.io/ChunkSplitters.jl/dev)
+[![Tests](https://img.shields.io/badge/build-passing-green)](https://github.com/JuliaFolds2/ChunkSplitters.jl/actions)
 [![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
 # ChunkSplitters.jl
 
-[ChunkSplitters.jl](https://github.com/m3g/ChunkSplitters.jl) facilitates the splitting of a given list of work items (of potentially uneven workload) into chunks that can be readily used for parallel processing. Operations on these chunks can, for example, be parallelized with Julia's multithreading tools, where separate tasks are created for each chunk. Compared to naive parallelization, ChunkSplitters.jl therefore effectively allows for more fine-grained control of the composition and workload of each parallel task.
+[ChunkSplitters.jl](https://github.com/JuliaFolds2/ChunkSplitters.jl) facilitates the splitting of a given list of work items (of potentially uneven workload) into chunks that can be readily used for parallel processing. Operations on these chunks can, for example, be parallelized with Julia's multithreading tools, where separate tasks are created for each chunk. Compared to naive parallelization, ChunkSplitters.jl therefore effectively allows for more fine-grained control of the composition and workload of each parallel task.
 
 Working with chunks and their respective indices also improves thread-safety compared to a naive approach based on `threadid()` indexing (see [PSA: Thread-local state is no longer recommended](https://julialang.org/blog/2023/07/PSA-dont-use-threadid/)). 
 
@@ -18,4 +18,4 @@ julia> import Pkg; Pkg.add("ChunkSplitters")
 
 ## Documentation
 
-Go to: [https://m3g.github.io/ChunkSplitters.jl](https://m3g.github.io/ChunkSplitters.jl)
+Go to: [https://JuliaFolds2.github.io/ChunkSplitters.jl](https://JuliaFolds2.github.io/ChunkSplitters.jl)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,7 +13,7 @@ makedocs(
     ]
 )
 deploydocs(
-    repo = "github.com/m3g/ChunkSplitters.jl.git",
+    repo = "github.com/JuliaFolds2/ChunkSplitters.jl.git",
     target = "build",
     branch = "gh-pages",
     devbranch = "main",

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,6 @@
 # ChunkSplitters.jl
 
-[ChunkSplitters.jl](https://github.com/m3g/ChunkSplitters.jl) facilitates the splitting of a given list of work items (of potentially uneven workload) into chunks that can be readily used for parallel processing. Operations on these chunks can, for example, be parallelized with Julia's multithreading tools, where separate tasks are created for each chunk. Compared to naive parallelization, ChunkSplitters.jl therefore effectively allows for more fine-grained control of the composition and workload of each parallel task.
+[ChunkSplitters.jl](https://github.com/JuliaFolds2/ChunkSplitters.jl) facilitates the splitting of a given list of work items (of potentially uneven workload) into chunks that can be readily used for parallel processing. Operations on these chunks can, for example, be parallelized with Julia's multithreading tools, where separate tasks are created for each chunk. Compared to naive parallelization, ChunkSplitters.jl therefore effectively allows for more fine-grained control of the composition and workload of each parallel task.
 
 Working with chunks and their respective indices also improves thread-safety compared to a naive approach based on `threadid()` indexing (see [PSA: Thread-local state is no longer recommended](https://julialang.org/blog/2023/07/PSA-dont-use-threadid/)). 
 

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -15,8 +15,11 @@ Pages   = ["ChunkSplitters.jl"]
 
 ## Interface requirements 
 
+!!! compat
+    Support for this minimal interface requires version 2.2.0.
+
 For the `chunks` and `getchunk` functions to work, the input value must
-have implemented only three methods extended from `Base`: `firstindex`,
+have implemented only three methods extended from Julia `Base`: `firstindex`,
 `lastindex`, and `length`.
 
 For example:

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -12,3 +12,37 @@ Order   = [:function, :type]
 Modules = [ChunkSplitters]
 Pages   = ["ChunkSplitters.jl"]
 ```
+
+## Interface requirements 
+
+For the `chunks` and `getchunk` functions to work, the input value must
+have implemented only three methods extended from `Base`: `firstindex`,
+`lastindex`, and `length`.
+
+For example:
+```jldoctest
+julia> using ChunkSplitters
+
+julia> struct MinimalInterface end
+
+julia> Base.firstindex(::MinimalInterface) = 1
+
+julia> Base.lastindex(::MinimalInterface) = 7
+
+julia> Base.length(::MinimalInterface) = 7
+
+julia> x = MinimalInterface()
+MinimalInterface()
+
+julia> collect(chunks(x; n=3))
+3-element Vector{StepRange{Int64, Int64}}:
+ 1:1:3
+ 4:1:5
+ 6:1:7
+
+julia> collect(chunks(x; n=3, split=:scatter))
+3-element Vector{StepRange{Int64, Int64}}:
+ 1:3:7
+ 2:3:5
+ 3:3:6
+```


### PR DESCRIPTION
- Move from m3g to JuliaFolds2
- Support non-AbstractArray types that have `firstindex`, `lastindex`, and `length` defined.
- Document minimal interface. 