### PR TITLE
Drop Compat dependency + Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         version:
           - 'lts'
-          - 'stable'
+          - '1' # latest stable 1.x release
           - 'pre'
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v3
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -44,6 +44,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           file: lcov.info
+
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
-          - '^1.6'
+          - 'lts'
+          - 'stable'
+          - 'pre'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -4,27 +4,25 @@ authors = ["Leandro Martinez <lmartine@unicamp.br> and contributors"]
 version = "2.4.6-DEV"
 
 [deps]
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
 
-[extras]
-OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-
 [compat]
-OffsetArrays = "1"
-julia = "1.6"
+Aqua = "0.8"
+BenchmarkTools = "1"
 Documenter = "1"
-Compat = "4.12"
+OffsetArrays = "1"
 Test = "1.6"
 TestItemRunner = "0.2"
 TestItems = "0.1, 1"
-Aqua = "0.8"
-BenchmarkTools = "1"
+julia = "1.6"
+
+[extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 
 [targets]
 test = ["Test", "TestItemRunner", "OffsetArrays", "Aqua", "Documenter", "BenchmarkTools"]


### PR DESCRIPTION
IMO, it is not worth it just for the `public` keyword. We can use the recommendation from https://docs.julialang.org/en/v1.12-dev/manual/modules/#Export-lists instead.