### PR TITLE
Simplify iterate method to remove allocation on 1.10.

### DIFF
--- a/src/internals.jl
+++ b/src/internals.jl
@@ -106,16 +106,12 @@ eltype(::IndexChunksIterator{T,C,RoundRobin}) where {T,C} = StepRange{Int,Int}
 eltype(c::ViewChunksIterator{T,C,Consecutive}) where {T,C} = typeof(c[firstindex(c)])
 eltype(c::ViewChunksIterator{T,C,RoundRobin}) where {T,C} = typeof(c[firstindex(c)])
 
-function iterate(c::AbstractChunksIterator{T,C,S}, state=nothing) where {T,C,S}
-    length(c.collection) == 0 && return nothing
-    if isnothing(state)
-        chunk = c[1]
-        return (chunk, 1)
-    elseif state < length(c)
-        chunk = c[state+1]
-        return (chunk, state + 1)
+function iterate(c::AbstractChunksIterator, state=firstindex(c))
+    if state > lastindex(c)
+        return nothing
+    else
+        return @inbounds(c[state]), state + 1
     end
-    return nothing
 end
 
 # Usually enumerate is not compatible

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -410,10 +410,6 @@ end
         b = @benchmark $f_chunks($x; n=4) samples = 1 evals = 1
         @test b.allocs == 0
         b = @benchmark $f_chunks($x; size=10) samples = 1 evals = 1
-        if VERSION < v"1.11.0-"
-            @test_broken b.allocs == 0 # TODO: why does this allocate on 1.10?
-        else
-            @test b.allocs == 0
-        end
+        @test b.allocs == 0
     end
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaFolds2/ChunkSplitters.jl/pull/48#issuecomment-2363287934