### PR TITLE
recover support for older Julia versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.6' # remove at some point in the future, if needed.
           - '1.10' # replace by 'lts' when this points to 1.10
           - '1' # latest stable 1.x release
           - 'pre'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ChunkSplitters.jl Changelog
 =========================
 
+Version 3.1.0
+-------------
+- ![INFO][badge-info] Recover support for Julia 1.6+. All tests pass from 1.9+, and an allocation test fails in 1.6.
+
+
 Version 3.0.0
 -------------
 - ![BREAKING][badge-breaking] The new lower compat bound for Julia is 1.10. This implies that support for the old LTS 1.6 has been dropped.

--- a/Project.toml
+++ b/Project.toml
@@ -10,10 +10,10 @@ Aqua = "0.8.5"
 BenchmarkTools = "1"
 Documenter = "1"
 OffsetArrays = "1"
-Test = "1.10"
+Test = "1.6"
 TestItemRunner = "1"
 TestItems = "1"
-julia = "1.10"
+julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -409,9 +409,11 @@ end
         x = rand(10^3)
         b = @benchmark $f_chunks($x; n=4) samples = 1 evals = 1
         @test b.allocs == 0
+        b = @benchmark $f_chunks($x; size=10) samples = 1 evals = 1
         if VERSION >= v"1.10"
-            b = @benchmark $f_chunks($x; size=10) samples = 1 evals = 1
             @test b.allocs == 0
+        else
+            @test_broken b.allocs == 0
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -409,7 +409,9 @@ end
         x = rand(10^3)
         b = @benchmark $f_chunks($x; n=4) samples = 1 evals = 1
         @test b.allocs == 0
-        b = @benchmark $f_chunks($x; size=10) samples = 1 evals = 1
-        @test b.allocs == 0
+        if VERSION >= v"1.10"
+            b = @benchmark $f_chunks($x; size=10) samples = 1 evals = 1
+            @test b.allocs == 0
+        end
     end
 end


### PR DESCRIPTION

@carstenbauer 

I started updating packages that depend on ChunkSplitters, and noted that we are artificially dropping support for older Julia versions than 1.10. Thus, if we are to suggest people to upgrade, everyone will be forced to drop their support as well. 

This is quite inconvenient now, particularly since 1.6 is (still) the LTS, and many people are using 1.9. I feel that suggesting PRs to packages that depend on ChunkSplitters while forcing them to drop support of older Julia versions just for it is not very nice.

The only test that fails in 1.6 is the allocation test with `size` set, but it does not fail in 1.9 anymore.