### PR TITLE
Allow `minsize` to exceed the collection length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ChunkSplitters.jl Changelog
 =========================
 
+Version 3.1.2
+-------------
+- ![ENHANCEMENT][badge-enhancement] Return a single chunk if `minsize > length(collection)`.
+
 Version 3.1.1
 -------------
 - ![BUGFIX][badge-bugfix] Throw an error if `minsize > length(collection)`. Before returned an empty collection of chunks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,9 @@ ChunkSplitters.jl Changelog
 
 Version 3.1.2
 -------------
-- ![BUGFIX][badge-bugfix] Indexing chunk iterators returns out-of-bounds error if the iterator is empty now (previously returned an empty range). 
-
-Version 3.1.2
--------------
 - ![ENHANCEMENT][badge-enhancement] Return a single chunk if `minsize > length(collection)`.
-
+- ![BUGFIX][badge-bugfix] Indexing chunk iterators returns out-of-bounds error if the iterator is empty now (previously returned an empty range).
+  
 Version 3.1.1
 -------------
 - ![BUGFIX][badge-bugfix] Throw an error if `minsize > length(collection)`. Before returned an empty collection of chunks.

--- a/src/api.jl
+++ b/src/api.jl
@@ -25,7 +25,8 @@ The keyword arguments `n` and `size` are mutually exclusive.
 * `minsize` can be used to specify the minimum size of a chunk,
   and can be used in combination with the `n` keyword. If, for the given `n`, the chunks
   are smaller than `minsize`, the number of chunks will be decreased to ensure that
-  each chunk is at least `minsize` long.
+  each chunk is at least `minsize` long. If `minsize` is greater than the length of the
+  collection, there will be only one chunk.
 
 ### Noteworthy
 
@@ -95,7 +96,8 @@ The keyword arguments `n` and `size` are mutually exclusive.
 * `minsize` can be used to specify the minimum size of a chunk,
   and can be used in combination with the `n` keyword. If, for the given `n`, the chunks
   are smaller than `minsize`, the number of chunks will be decreased to ensure that
-  each chunk is at least `minsize` long.
+  each chunk is at least `minsize` long. If `minsize` is greater than the length of the
+  collection, there will be only one chunk.
 
 ### Noteworthy
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -98,7 +98,7 @@ The keyword arguments `n` and `size` are mutually exclusive.
   and can be used in combination with the `n` keyword. If, for the given `n`, the chunks
   are smaller than `minsize`, the number of chunks will be decreased to ensure that
   each chunk is at least `minsize` long. By default, `minsize == 1` when the keyword
-  is set to `nothing`.If `minsize` is greater than the length of the
+  is set to `nothing`. If `minsize` is greater than the length of the
   collection, there will be only one chunk.
 
 ### Noteworthy

--- a/src/internals.jl
+++ b/src/internals.jl
@@ -66,7 +66,7 @@ is_chunkable(::AbstractChunks) = true
 _set_minsize(minsize::Nothing, _) = 1
 function _set_minsize(minsize::Integer, collection_length::Integer)
     minsize < 1 && throw(ArgumentError("minsize must be >= 1"))
-    return min(minsize, collection_length)
+    return max(min(minsize, collection_length), 1)
 end
 function _set_C_n_size(collection, n::Nothing, size::Integer, minsize)
     !isnothing(minsize) && err_mutually_exclusive("size", "minsize")

--- a/src/internals.jl
+++ b/src/internals.jl
@@ -66,8 +66,7 @@ is_chunkable(::AbstractChunks) = true
 _set_minsize(minsize::Nothing, _) = 1
 function _set_minsize(minsize::Integer, collection_length::Integer)
     minsize < 1 && throw(ArgumentError("minsize must be >= 1"))
-    minsize > collection_length && throw(ArgumentError("minsize must be <= length(collection)"))
-    return minsize
+    return min(minsize, collection_length)
 end
 function _set_C_n_size(collection, n::Nothing, size::Integer, minsize)
     !isnothing(minsize) && err_mutually_exclusive("size", "minsize")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -312,6 +312,7 @@ end
             @test collect(f(1:10; n=2, minsize=2)) == [1:5, 6:10]
             @test collect(f(1:10; n=5, minsize=3)) == [1:4, 5:7, 8:10]
             @test collect(f(1:11; n=10, minsize=3)) == [1:4, 5:8, 9:11]
+            @test collect(f(1:10; n=10, minsize=20)) == [1:10]
             @test_throws ArgumentError f(1:10; n=2, minsize=0)
             @test_throws ArgumentError f(1:10; size=2, minsize=2)
             @test_throws ArgumentError f(1:10; size=2, minsize=11)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -313,6 +313,7 @@ end
             @test collect(f(1:10; n=5, minsize=3)) == [1:4, 5:7, 8:10]
             @test collect(f(1:11; n=10, minsize=3)) == [1:4, 5:8, 9:11]
             @test collect(f(1:10; n=10, minsize=20)) == [1:10]
+            @test collect(f(1:0;  n=10, minsize=10)) == []
             @test_throws ArgumentError f(1:10; n=2, minsize=0)
             @test_throws ArgumentError f(1:10; size=2, minsize=2)
             @test_throws ArgumentError f(1:10; size=2, minsize=11)


### PR DESCRIPTION
For me, the whole reason I want something like `minsize` is that I don't want to write code that checks the length of the collection every time I pass it to ChunkSplitters (or OhMyThreads), so I think making `minsize` do `min(minsize, collection_length)` makes sense here. It basically just disables chunking if the collection is sufficiently small. Throwing an error feels counterproductive. 

This PR is needed for a change I want to make to OhMyThreads.

That is, it's important for me to be able to write something like
```julia
function f(coll)
    for chunk in chunks(coll; n=10, minsize=100)
        do_something(chunk)
    end
end
```
and not worry about it throwing an error at me.